### PR TITLE
Fix links naar LDV werkversies

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -31,8 +31,8 @@ De Logboek Dataverwerkingen (LDV) standaard bestaat uit de volgende drie documen
 | Beschrijving van het document           | Gepubliceerde versie                  | Werk versie                             | Repository                                                   |
 | --------------------------------------- | ------------------------------------- | --------------------------------------- | ------------------------------------------------------------ |
 | 1. De LDV Normatieve Standaard | - | [Logboek dataverwerkingen (werkversie)](https://logius-standaarden.github.io/logboek-dataverwerkingen/) | [logboek-dataverwerkingen](https://github.com/Logius-standaarden/logboek-dataverwerkingen) |
-| 2. De Algemene Inleiding | - | [De Algemene Inleiding (werkversie)](https://logius-standaarden.github.io/publicatie/api/Logboek_Algemeen/)|[logboek-dataverwerkingen_Inleiding](https://github.com/Logius-standaarden/logboek-dataverwerkingen_Inleiding)|
-| 3. het Juridische Beleidskader | - |[Juridisch Beleidskader (werkversie)](https://logius-standaarden.github.io/publicatie/api/Logboek_Juridisch/)|[logboek-dataverwerkingen_Juridisch-beleidskader](https://github.com/Logius-standaarden/logboek-dataverwerkingen_Juridisch-beleidskader/)|
+| 2. De Algemene Inleiding | - | [De Algemene Inleiding (werkversie)](https://logius-standaarden.github.io/logboek-dataverwerkingen_Inleiding/)|[logboek-dataverwerkingen_Inleiding](https://github.com/Logius-standaarden/logboek-dataverwerkingen_Inleiding)|
+| 3. het Juridische Beleidskader | - |[Juridisch Beleidskader (werkversie)](https://logius-standaarden.github.io/logboek-dataverwerkingen_Juridisch-beleidskader/)|[logboek-dataverwerkingen_Juridisch-beleidskader](https://github.com/Logius-standaarden/logboek-dataverwerkingen_Juridisch-beleidskader/)|
    
 </details>
 


### PR DESCRIPTION
Beide URLs klopten niet en zijn geupdate naar de versies die wel gepubliceerd zijn. Mogelijk willen we alsnog de versies op de URLs publiceren, maar dat vereist updates aan de publicatie infrastructuur.